### PR TITLE
Add non-interactive `--yes` flag to init-bundles and use in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node ./ranvier -v",
-    "ci:init": "node ./util/ci-install-bundles.js",
+    "ci:init": "node ./util/init-bundles.js --yes",
     "init": "node ./util/init-bundles.js",
     "update-bundle-remote": "node ./util/update-bundle-url.js",
     "remove-bundle": "node ./util/remove-bundle.js",

--- a/util/init-bundles.js
+++ b/util/init-bundles.js
@@ -23,7 +23,9 @@ async function prompt() {
 async function main() {
 
   try {
-    let answer = await prompt();
+    const argv = process.argv.slice(2);
+    const shouldPrompt = !argv.includes('--yes') && !argv.includes('-y');
+    const answer = shouldPrompt ? await prompt() : 'y';
 
     if (answer === 'n') {
       throw 'foo';


### PR DESCRIPTION
### Motivation
- Allow the bundles initialization script to run non-interactively so CI can perform repository setup without hanging on a prompt.

### Description
- `util/init-bundles.js` now accepts `--yes` or `-y` and will skip the interactive prompt, treating the response as yes when those flags are present.
- The `ci:init` npm script in `package.json` was updated to call `node ./util/init-bundles.js --yes` to enable non-interactive CI usage.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ffa2e40c8326b50cff2224bd8893)