### PR TITLE
Upgrade semver to ^7.6.0 and refresh lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ranvier": "github:Ranvire/core",
         "ranvier-datasource-file": "github:Ranvire/datasource-file",
         "ranvier-telnet": "github:Ranvire/ranvier-telnet",
-        "semver": "^5.6.0",
+        "semver": "^7.6.0",
         "sprintf-js": "^1.0.3",
         "sty": "0.6.1",
         "uuid": "^3.3.2",
@@ -1195,11 +1195,15 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ranvier": "github:Ranvire/core",
     "ranvier-datasource-file": "github:Ranvire/datasource-file",
     "ranvier-telnet": "github:Ranvire/ranvier-telnet",
-    "semver": "^5.6.0",
+    "semver": "^7.6.0",
     "sprintf-js": "^1.0.3",
     "sty": "0.6.1",
     "uuid": "^3.3.2",


### PR DESCRIPTION
### Motivation
- Remove a known vulnerable old `semver` version by upgrading the direct dependency to a maintained 7.x series. 
- Keep runtime behavior unchanged since `semver` is only used to check the Node engine in the wrapper. 
- Limit changes to only the `semver` dependency and the lockfile to satisfy the constraint of minimal scope.

### Description
- Bumped `semver` in `package.json` from `^5.6.0` to `^7.6.0`.
- Ran `npm install` to update `package-lock.json`, which resolved `semver` to `7.7.4` and updated package metadata (`bin` and `engines`).
- No runtime code changes were made; `ranvier` continues to call `semver.satisfies(process.version, pkg.engines.node)`. 
- The only modified files are `package.json` and `package-lock.json`.

### Testing
- Ran `npm test`, which executed the Mocha suite and resulted in `7 passing` tests.
- Ran `npm run smoke:login`, which failed with: `Timed out waiting for telnet readiness output` (the smoke script waits 30s for readiness regexes and did not detect the server line). 
- `npm run smoke:world` is not defined in `package.json` so it was not run.
- Proposed minimal fix for the smoke failure is to update `util/smoke-login.js` to either extend the readiness timeout or add the actual server readiness log line to `READY_REGEXES`; no other dependency upgrades are required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873dac5b448326b567369c462e5b47)