### PR TITLE
Add ranvier core error catch-and-exit-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All entries follow `docs/CHANGELOG_POLICY.md`.
+
+## Unreleased
+
+### Explicit startup failure handling
+
+- Summary:
+  - Added an explicit top-level catch around server initialization to handle startup failures from the core engine.
+- Why:
+  - Core bundle and area load failures now surface as thrown errors rather than terminating the process internally.
+  - The wrapper is responsible for deciding how to log and exit on startup failure.
+- Impact:
+  - Startup failures now reliably result in a non-zero process exit and a visible stack trace.
+  - Server startup still fails fast on invalid bundles or hydration errors.
+- Migration/Action:
+  - None.
+  - Existing deployments will see clearer failure signaling and correct exit codes on startup errors.
+- References:
+  - PR: #15 Add explicit init error handling for core startup failures
+- Timestamp: 2026.02.10 16:25

--- a/docs/CHANGELOG_POLICY.md
+++ b/docs/CHANGELOG_POLICY.md
@@ -1,0 +1,67 @@
+# Changelog Policy (Maintenance Releases)
+
+This repository is a maintenance and stewardship fork of RanvierMUD. The changelog exists to document:
+
+- user-visible changes,
+- dependency and security actions,
+- runtime/CI changes, and
+- deliberate drifts or modernizations relative to the original RanvierMUD behavior or dependencies.
+
+The policy below is intentionally lightweight. It should be followed by maintainers, downstream game repo owners, bundle authors, and automated agents working on the core engine.
+
+## Canonical locations
+
+- **Policy:** `docs/CHANGELOG_POLICY.md` (this document).
+- **Entries:** `CHANGELOG.md` at the repo root.
+
+## When to add an entry
+
+Add or update a changelog entry when a change is:
+
+- user-visible (behavior changes, error handling, logging, diagnostics),
+- dependency or security related (upgrades, removals, vulnerability responses),
+- runtime/CI related (Node version support, build tooling, CI matrices),
+- compatibility-impacting (even if intended to be backward compatible),
+- a deliberate drift or modernization from RanvierMUD behavior or dependencies.
+
+## Required entry fields (per release or grouped change set)
+
+Each changelog entry must include:
+
+- **Summary:** short description of what changed.
+- **Why:** motivation or rationale (especially for drifts/modernizations).
+- **Impact:** who is affected and how (compatibility or operational impact).
+- **Migration/Action:** required steps for downstream users, or “None.”
+- **References:** relevant issues/PRs or commit identifiers if applicable.
+- **Timestamp:** the *current* date and time in the format YYYY.MM.DD hh:mm
+
+## Drift/modernization documentation
+
+When documenting drift from RanvierMUD, be explicit about:
+
+- the original RanvierMUD behavior or dependency,
+- the current behavior or replacement,
+- why the change was made,
+- any operational or compatibility implications.
+
+## Format (recommended)
+
+Use a simple, consistent structure in `CHANGELOG.md`:
+
+```
+## Unreleased
+
+### Drift / Modernization
+- Summary:
+  - ...
+- Why:
+  - ...
+- Impact:
+  - ...
+- Migration/Action:
+  - ...
+- References:
+  - ...
+```
+
+If a category has no changes, omit it. Keep entries short and scannable.

--- a/ranvier
+++ b/ranvier
@@ -173,5 +173,10 @@ if (testMode && testOutputPath) {
     fs.writeFileSync(testOutputPath, JSON.stringify(testPayload, null, 2));
     process.exitCode = 1;
   });
+} else {
+  initPromise.catch((err) => {
+    console.error(err && err.stack ? err.stack : err);
+    process.exitCode = 1;
+  });
 }
 // vim: set syn=javascript :


### PR DESCRIPTION
Add an error catch at the load-core-and-run-it promise, to catch the errors added in lieu of the `process.exit(0)`s