### PR TITLE
bundle-test: support multi-command scenario input

### DIFF
--- a/docs/BundleValidationUserManual.md
+++ b/docs/BundleValidationUserManual.md
@@ -1,0 +1,212 @@
+# Bundle Validation User Manual
+
+## What this is
+
+The **Bundle Validation and Testing Framework** is a set of wrapper-repo tools that helps you check whether your enabled bundles are healthy **before** starting the game server.
+
+It includes these commands:
+
+- `npm run validate:bundles` — checks bundle filesystem structure
+- `node util/validate-bundles.js --engine` — loads bundles through the engine (without starting telnet/transports)
+- `node util/validate-bundles.js --engine --players` — also checks saved player attributes for compatibility
+- `npm run test:bundles` — runs bundle-local `npm test` scripts when they exist
+- `npm run test:bundles:contract` — runs wrapper-level contract tests
+
+---
+
+## What it is for
+
+This tooling is for catching common integration problems early and deterministically, such as:
+
+- a configured bundle folder being missing
+- area folders missing `manifest.yml`
+- empty `help/` content
+- engine-time bundle load errors
+- unknown persisted player attributes after bundle changes
+- bundle test suite regressions (when bundle-local tests are available)
+
+In short: it helps you answer, “Are my enabled bundles safe to ship and run?”
+
+---
+
+## Who would use it
+
+Typical users include:
+
+- **Maintainers** of this wrapper repository validating changes before merge
+- **Bundle authors** checking compatibility against a real wrapper setup
+- **CI pipelines / automation** that need machine-readable validation (`--json`)
+- **Operators** preparing a deployment and wanting a fast preflight check
+
+---
+
+## Prototypical use case
+
+### Scenario
+
+You updated one or more bundles (or changed enabled bundle config) and want confidence that startup and persisted data compatibility are still okay.
+
+### Files involved
+
+- Config file (required):
+  - `ranvier.conf.js` (preferred if present), or
+  - `ranvier.json`
+- Bundles directory:
+  - `bundles/<bundleName>/...`
+- Optional persisted player data:
+  - `data/player/*.json` (via configured player entity loader)
+
+### Typical command flow
+
+Run from repository root:
+
+1. **Fast structure validation**
+   ```bash
+   npm run validate:bundles
+   ```
+
+2. **Engine bundle-load validation (no transports/telnet startup)**
+   ```bash
+   node util/validate-bundles.js --engine
+   ```
+
+3. **Persisted player compatibility check**
+   ```bash
+   node util/validate-bundles.js --engine --players
+   ```
+
+4. **Strict mode for CI gate (treat unknown player attributes as errors)**
+   ```bash
+   node util/validate-bundles.js --engine --players --strict
+   ```
+
+5. **Run bundle-local tests when present**
+   ```bash
+   npm run test:bundles
+   ```
+
+6. **Run wrapper contract coverage**
+   ```bash
+   npm run test:bundles:contract
+   ```
+
+If all required steps pass, you have strong confidence in bundle integration health.
+
+---
+
+## Philosophy: why this exists and how it works
+
+This framework is intentionally designed around a maintenance-first philosophy:
+
+- **Deterministic and non-interactive**: safe for unattended runs and CI.
+- **Layered checks**: start with low-cost filesystem checks, then engine load, then persistence compatibility.
+- **Compatibility-aware**: checks are aligned with actual wrapper config and bundle loading behavior.
+- **Minimal impact**: no telnet binding or server startup required for validation flows.
+- **Actionable results**: findings include level (`warn`/`error`), a stable code, and contextual metadata.
+
+### Findings model
+
+Findings are structured objects with this shape:
+
+```js
+{ level, code, message, bundle?, area?, path?, detail? }
+```
+
+- `level` is either `warn` or `error`
+- `error` findings cause non-zero exit status
+- `warn` findings are informational unless upgraded (e.g., by `--strict` in players mode)
+
+### Human output vs JSON output
+
+- Default output: human-readable lines for local development
+- `--json`: emits a JSON array only, making it easy for scripts/CI to parse
+
+---
+
+## Advanced usage
+
+## 1) Machine-readable CI integration
+
+Use JSON mode and fail on errors:
+
+```bash
+node util/validate-bundles.js --engine --players --strict --json
+```
+
+This supports policy automation such as:
+
+- parse findings and annotate pull requests
+- block deployment when any `error` finding exists
+- trend warning/error counts over time
+
+## 2) Choosing warning policy for player attributes
+
+Unknown persisted player attributes are a compatibility signal.
+
+- Use `--engine --players` during exploratory work to collect warnings.
+- Use `--engine --players --strict` for release gating when you want hard failure.
+
+## 3) Using wrapper and bundle tests together
+
+A practical order for deeper validation:
+
+```bash
+npm run validate:bundles
+node util/validate-bundles.js --engine --players --strict
+npm run test:bundles
+npm run test:bundles:contract
+```
+
+This gives broad coverage with quick failure for obvious breakage.
+
+
+## 4) Scenario runner command sequences
+
+You can run multiple commands in one scenario pass:
+
+```bash
+node util/scenario-runner.js --command-line "look" --command-line "north" --command-line "inventory"
+```
+
+Or store commands in a line-separated file (`#` comments and blank lines are ignored):
+
+```text
+# test/scenarios/smoke.commands
+look
+north
+look
+inventory
+```
+
+Then run:
+
+```bash
+node util/scenario-runner.js --commands-file test/scenarios/smoke.commands
+```
+
+## 5) Troubleshooting common failures
+
+- **`CONFIG_NOT_FOUND`**
+  - Add `ranvier.conf.js` or `ranvier.json` at repo root.
+- **`BUNDLE_DIR_MISSING`**
+  - Ensure bundle name in config matches `bundles/<name>/` exactly.
+- **`AREA_MANIFEST_MISSING`**
+  - Add `manifest.yml` under each area folder.
+- **`ENGINE_LOAD_FAILED`**
+  - Inspect stack trace in finding `detail` and fix bundle load issue.
+- **`UNKNOWN_PLAYER_ATTRIBUTE`**
+  - Either restore compatible attributes in bundles, migrate stored data, or run non-strict while planning migration.
+
+---
+
+## Quick start checklist
+
+- [ ] Config file exists (`ranvier.conf.js` or `ranvier.json`)
+- [ ] Enabled bundles are present under `bundles/`
+- [ ] `npm run validate:bundles` passes
+- [ ] `node util/validate-bundles.js --engine` passes
+- [ ] `node util/validate-bundles.js --engine --players` reviewed (or strict-gated)
+- [ ] `npm run test:bundles` completed
+- [ ] `npm run test:bundles:contract` passes
+
+When this checklist is green, you are in a good place to merge or deploy.

--- a/docs/bundle-testing-template.md
+++ b/docs/bundle-testing-template.md
@@ -1,0 +1,52 @@
+# Bundle Testing Template (`node:test`)
+
+Use this template in a bundle repository to enable lightweight unit tests with Node's built-in test runner.
+
+## `package.json` snippet
+
+```json
+{
+  "scripts": {
+    "test": "node --test"
+  }
+}
+```
+
+## Suggested layout
+
+- `lib/` for pure logic modules
+- `test/` for test files
+
+Example:
+
+```text
+my-bundle/
+  lib/
+    combat-math.js
+  test/
+    combat-math.test.js
+  package.json
+```
+
+## Example test
+
+```js
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function add(a, b) {
+  return a + b;
+}
+
+test('add() sums two numbers', () => {
+  assert.equal(add(2, 3), 5);
+});
+```
+
+Run tests with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "remove-bundle": "node ./util/remove-bundle.js",
     "install-bundle": "node ./util/install-bundle.js",
     "smoke:login": "node ./scripts/smoke-login.js",
-    "test": "mocha"
+    "test": "mocha",
+    "validate:bundles": "node util/validate-bundles.js",
+    "test:bundles": "node util/test-bundles.js",
+    "test:bundles:contract": "node --test test/bundles.contract.test.js",
+    "scenario": "node util/scenario-runner.js"
   },
   "dependencies": {
     "commander": "^2.19.0",

--- a/test/bundles.contract.test.js
+++ b/test/bundles.contract.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+
+function runValidation(args) {
+  return spawnSync(process.execPath, ['util/validate-bundles.js', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+test('bundle validation in engine mode returns parseable findings without errors', () => {
+  const result = runValidation(['--engine', '--json']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const findings = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(findings), 'Expected findings to be a JSON array');
+
+  const errors = findings.filter((finding) => finding.level === 'error');
+  assert.equal(errors.length, 0, `Expected no error findings, got ${errors.length}`);
+});
+
+test('player validation mode completes and returns parseable findings', () => {
+  const result = runValidation(['--engine', '--players', '--json']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const findings = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(findings), 'Expected findings to be a JSON array');
+});

--- a/test/scenario.example.test.js
+++ b/test/scenario.example.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+
+test('scenario runner help exits successfully', () => {
+  const result = spawnSync(process.execPath, ['util/scenario-runner.js', '--help'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /--commands-file/);
+  assert.match(result.stdout, /--command-line/);
+});

--- a/util/scenario-runner.js
+++ b/util/scenario-runner.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function printHelp() {
+  console.log('Usage: node util/scenario-runner.js [--command-line "look"] [--commands-file <path>]');
+  console.log('       node util/scenario-runner.js [--command <name>] [--args "<args>"]');
+  console.log('Boots the engine in no-transport mode, loads bundles, and executes one or more commands.');
+  console.log('Command files are line-separated: one command per line, # for comments, blank lines ignored.');
+}
+
+function loadConfig(root) {
+  const confPath = path.join(root, 'ranvier.conf.js');
+  const jsonPath = path.join(root, 'ranvier.json');
+
+  if (fs.existsSync(confPath)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(confPath);
+  }
+
+  if (fs.existsSync(jsonPath)) {
+    return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  }
+
+  throw new Error('No ranvier.json or ranvier.conf.js found');
+}
+
+function parseCommandLine(line) {
+  const trimmed = String(line || '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const spaceIndex = trimmed.indexOf(' ');
+  if (spaceIndex === -1) {
+    return { raw: trimmed, name: trimmed, args: '' };
+  }
+
+  return {
+    raw: trimmed,
+    name: trimmed.slice(0, spaceIndex),
+    args: trimmed.slice(spaceIndex + 1).trim(),
+  };
+}
+
+function readCommandsFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  return content
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+function collectCommandLines(args, root) {
+  const commandLines = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === '--command-line') {
+      if (i + 1 >= args.length) {
+        throw new Error('Missing value for --command-line');
+      }
+
+      commandLines.push(args[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--commands-file') {
+      if (i + 1 >= args.length) {
+        throw new Error('Missing value for --commands-file');
+      }
+
+      const commandFilePath = path.resolve(root, args[i + 1]);
+      commandLines.push(...readCommandsFile(commandFilePath));
+      i += 1;
+    }
+  }
+
+  if (!commandLines.length) {
+    const commandIndex = args.indexOf('--command');
+    const commandName = commandIndex >= 0 ? args[commandIndex + 1] : 'look';
+    const argIndex = args.indexOf('--args');
+    const commandArgs = argIndex >= 0 ? args[argIndex + 1] : '';
+    commandLines.push(commandArgs ? `${commandName} ${commandArgs}` : commandName);
+  }
+
+  return commandLines;
+}
+
+async function bootEngine(root, config) {
+  const Ranvier = require('ranvier');
+  Ranvier.Data.setDataPath(path.join(root, 'data'));
+  Ranvier.Config.load(config);
+
+  const GameState = {
+    AccountManager: new Ranvier.AccountManager(),
+    AreaBehaviorManager: new Ranvier.BehaviorManager(),
+    AreaFactory: new Ranvier.AreaFactory(),
+    AreaManager: new Ranvier.AreaManager(),
+    AttributeFactory: new Ranvier.AttributeFactory(),
+    ChannelManager: new Ranvier.ChannelManager(),
+    CommandManager: new Ranvier.CommandManager(),
+    Config: Ranvier.Config,
+    EffectFactory: new Ranvier.EffectFactory(),
+    HelpManager: new Ranvier.HelpManager(),
+    InputEventManager: new Ranvier.EventManager(),
+    ItemBehaviorManager: new Ranvier.BehaviorManager(),
+    ItemFactory: new Ranvier.ItemFactory(),
+    ItemManager: new Ranvier.ItemManager(),
+    MobBehaviorManager: new Ranvier.BehaviorManager(),
+    MobFactory: new Ranvier.MobFactory(),
+    MobManager: new Ranvier.MobManager(),
+    PartyManager: new Ranvier.PartyManager(),
+    PlayerManager: new Ranvier.PlayerManager(),
+    QuestFactory: new Ranvier.QuestFactory(),
+    QuestGoalManager: new Ranvier.QuestGoalManager(),
+    QuestRewardManager: new Ranvier.QuestRewardManager(),
+    RoomBehaviorManager: new Ranvier.BehaviorManager(),
+    RoomFactory: new Ranvier.RoomFactory(),
+    RoomManager: new Ranvier.RoomManager(),
+    SkillManager: new Ranvier.SkillManager(),
+    SpellManager: new Ranvier.SkillManager(),
+    ServerEventManager: new Ranvier.EventManager(),
+    GameServer: new Ranvier.GameServer(),
+    DataLoader: Ranvier.Data,
+    EntityLoaderRegistry: new Ranvier.EntityLoaderRegistry(),
+    DataSourceRegistry: new Ranvier.DataSourceRegistry(),
+  };
+
+  GameState.DataSourceRegistry.load(require, root, config.dataSources);
+  GameState.EntityLoaderRegistry.load(GameState.DataSourceRegistry, config.entityLoaders);
+  GameState.AccountManager.setLoader(GameState.EntityLoaderRegistry.get('accounts'));
+  GameState.PlayerManager.setLoader(GameState.EntityLoaderRegistry.get('players'));
+
+  const bundleManager = new Ranvier.BundleManager(`${path.join(root, 'bundles')}/`, GameState);
+  GameState.BundleManager = bundleManager;
+  await bundleManager.loadBundles();
+
+  return GameState;
+}
+
+function createFakePlayer(output) {
+  return {
+    name: 'ScenarioPlayer',
+    commandQueue: [],
+    socket: { write: (line) => output.push(String(line)) },
+    send: (line) => output.push(String(line)),
+    echo: (line) => output.push(String(line)),
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help')) {
+    printHelp();
+    return;
+  }
+
+  const root = process.cwd();
+  const commandLines = collectCommandLines(args, root);
+  const parsedCommands = commandLines.map(parseCommandLine).filter(Boolean);
+
+  if (!parsedCommands.length) {
+    throw new Error('No commands were provided to execute');
+  }
+
+  const config = loadConfig(root);
+  const GameState = await bootEngine(root, config);
+  const output = [];
+  const player = createFakePlayer(output);
+
+  console.log(`[info] scenario starting (commands=${parsedCommands.length})`);
+
+  for (let i = 0; i < parsedCommands.length; i += 1) {
+    const commandSpec = parsedCommands[i];
+    const commandMatch = GameState.CommandManager.find(commandSpec.name, true);
+
+    if (!commandMatch) {
+      console.error(`[error] command ${i + 1}/${parsedCommands.length} not found: ${commandSpec.name}`);
+      process.exit(1);
+      return;
+    }
+
+    const { command, alias } = commandMatch;
+    console.log(`[run] ${i + 1}/${parsedCommands.length}: ${commandSpec.raw}`);
+    await command.execute(commandSpec.args, player, alias);
+  }
+
+  if (output.length) {
+    process.stdout.write(`${output.join('\n')}\n`);
+  }
+
+  console.log(`[info] scenario complete (commands=${parsedCommands.length}, failed=0)`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/util/test-bundles.js
+++ b/util/test-bundles.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function loadConfig(root) {
+  const confPath = path.join(root, 'ranvier.conf.js');
+  const jsonPath = path.join(root, 'ranvier.json');
+
+  if (fs.existsSync(confPath)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(confPath);
+  }
+
+  if (fs.existsSync(jsonPath)) {
+    return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  }
+
+  throw new Error('No ranvier.json or ranvier.conf.js found');
+}
+
+function main() {
+  const root = process.cwd();
+  const config = loadConfig(root);
+  const bundles = Array.isArray(config.bundles) ? config.bundles : [];
+  let failed = false;
+  let ran = 0;
+  let skipped = 0;
+
+  console.log(`[info] test:bundles starting (enabled=${bundles.length})`);
+
+  for (const bundle of bundles) {
+    const bundlePath = path.join(root, 'bundles', bundle);
+    const packagePath = path.join(bundlePath, 'package.json');
+
+    if (!fs.existsSync(packagePath)) {
+      console.log(`[skip] ${bundle}: no package.json`);
+      skipped += 1;
+      continue;
+    }
+
+    const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    if (!pkg.scripts || !pkg.scripts.test) {
+      console.log(`[skip] ${bundle}: no test script`);
+      skipped += 1;
+      continue;
+    }
+
+    console.log(`[run] ${bundle}: npm test`);
+    ran += 1;
+    const result = spawnSync('npm', ['test'], {
+      cwd: bundlePath,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+
+    if (result.status !== 0) {
+      failed = true;
+    }
+  }
+
+  if (bundles.length === 0) {
+    console.log('[info] no enabled bundles configured');
+  }
+
+  console.log(`[info] test:bundles complete (ran=${ran}, skipped=${skipped}, failed=${failed ? 1 : 0})`);
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/util/validate-bundles.js
+++ b/util/validate-bundles.js
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function loadConfig(root, findings) {
+  const confPath = path.join(root, 'ranvier.conf.js');
+  const jsonPath = path.join(root, 'ranvier.json');
+
+  if (fs.existsSync(confPath)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(confPath);
+  }
+
+  if (fs.existsSync(jsonPath)) {
+    return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  }
+
+  findings.push({
+    level: 'error',
+    code: 'CONFIG_NOT_FOUND',
+    message: 'No ranvier.json or ranvier.conf.js found',
+    path: root,
+  });
+
+  return null;
+}
+
+function hasYamlFiles(dirPath) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  return entries.some((entry) => entry.isFile() && entry.name.endsWith('.yml'));
+}
+
+function formatFinding(finding) {
+  const context = [];
+  if (finding.bundle) {
+    context.push(`bundle=${finding.bundle}`);
+  }
+  if (finding.area) {
+    context.push(`area=${finding.area}`);
+  }
+  if (finding.path) {
+    context.push(`path=${finding.path}`);
+  }
+
+  const contextText = context.length ? ` (${context.join(', ')})` : '';
+  return `[${finding.level.toUpperCase()}] ${finding.code}: ${finding.message}${contextText}`;
+}
+
+function validateFilesystem(root, config, findings) {
+  const bundles = Array.isArray(config.bundles) ? config.bundles : [];
+
+  for (const bundle of bundles) {
+    const bundlePath = path.join(root, 'bundles', bundle);
+    const relBundlePath = path.join('bundles', bundle);
+
+    if (!fs.existsSync(bundlePath) || !fs.statSync(bundlePath).isDirectory()) {
+      findings.push({
+        level: 'error',
+        code: 'BUNDLE_DIR_MISSING',
+        message: 'Missing bundle directory',
+        bundle,
+        path: relBundlePath,
+      });
+      continue;
+    }
+
+    const areasPath = path.join(bundlePath, 'areas');
+    if (fs.existsSync(areasPath) && fs.statSync(areasPath).isDirectory()) {
+      const areaDirs = fs.readdirSync(areasPath, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+      for (const areaDir of areaDirs) {
+        const manifestPath = path.join(areasPath, areaDir.name, 'manifest.yml');
+        if (!fs.existsSync(manifestPath)) {
+          findings.push({
+            level: 'warn',
+            code: 'AREA_MANIFEST_MISSING',
+            message: 'Area manifest.yml is missing',
+            bundle,
+            area: areaDir.name,
+            path: path.join(relBundlePath, 'areas', areaDir.name, 'manifest.yml'),
+          });
+        }
+      }
+    }
+
+    const helpPath = path.join(bundlePath, 'help');
+    if (fs.existsSync(helpPath) && fs.statSync(helpPath).isDirectory() && !hasYamlFiles(helpPath)) {
+      findings.push({
+        level: 'warn',
+        code: 'HELP_YAML_MISSING',
+        message: 'Help directory contains no .yml files',
+        bundle,
+        path: path.join(relBundlePath, 'help'),
+      });
+    }
+  }
+}
+
+
+function summarizeFindings(findings) {
+  const counts = { error: 0, warn: 0 };
+  for (const finding of findings) {
+    if (finding.level === 'error') {
+      counts.error += 1;
+    } else if (finding.level === 'warn') {
+      counts.warn += 1;
+    }
+  }
+
+  return counts;
+}
+
+async function validateEngineLoad(root, config, findings) {
+  try {
+    const Ranvier = require('ranvier');
+    Ranvier.Data.setDataPath(path.join(root, 'data'));
+    Ranvier.Config.load(config);
+
+    const GameState = {
+      AccountManager: new Ranvier.AccountManager(),
+      AreaBehaviorManager: new Ranvier.BehaviorManager(),
+      AreaFactory: new Ranvier.AreaFactory(),
+      AreaManager: new Ranvier.AreaManager(),
+      AttributeFactory: new Ranvier.AttributeFactory(),
+      ChannelManager: new Ranvier.ChannelManager(),
+      CommandManager: new Ranvier.CommandManager(),
+      Config: Ranvier.Config,
+      EffectFactory: new Ranvier.EffectFactory(),
+      HelpManager: new Ranvier.HelpManager(),
+      InputEventManager: new Ranvier.EventManager(),
+      ItemBehaviorManager: new Ranvier.BehaviorManager(),
+      ItemFactory: new Ranvier.ItemFactory(),
+      ItemManager: new Ranvier.ItemManager(),
+      MobBehaviorManager: new Ranvier.BehaviorManager(),
+      MobFactory: new Ranvier.MobFactory(),
+      MobManager: new Ranvier.MobManager(),
+      PartyManager: new Ranvier.PartyManager(),
+      PlayerManager: new Ranvier.PlayerManager(),
+      QuestFactory: new Ranvier.QuestFactory(),
+      QuestGoalManager: new Ranvier.QuestGoalManager(),
+      QuestRewardManager: new Ranvier.QuestRewardManager(),
+      RoomBehaviorManager: new Ranvier.BehaviorManager(),
+      RoomFactory: new Ranvier.RoomFactory(),
+      RoomManager: new Ranvier.RoomManager(),
+      SkillManager: new Ranvier.SkillManager(),
+      SpellManager: new Ranvier.SkillManager(),
+      ServerEventManager: new Ranvier.EventManager(),
+      GameServer: new Ranvier.GameServer(),
+      DataLoader: Ranvier.Data,
+      EntityLoaderRegistry: new Ranvier.EntityLoaderRegistry(),
+      DataSourceRegistry: new Ranvier.DataSourceRegistry(),
+    };
+
+    GameState.DataSourceRegistry.load(require, root, config.dataSources);
+    GameState.EntityLoaderRegistry.load(GameState.DataSourceRegistry, config.entityLoaders);
+
+    GameState.AccountManager.setLoader(GameState.EntityLoaderRegistry.get('accounts'));
+    GameState.PlayerManager.setLoader(GameState.EntityLoaderRegistry.get('players'));
+
+    const bundleManager = new Ranvier.BundleManager(`${path.join(root, 'bundles')}/`, GameState);
+    GameState.BundleManager = bundleManager;
+    await bundleManager.loadBundles();
+
+    return GameState;
+  } catch (error) {
+    findings.push({
+      level: 'error',
+      code: 'ENGINE_LOAD_FAILED',
+      message: 'Bundle load failed in --engine mode',
+      detail: {
+        message: error.message,
+        stack: error.stack,
+      },
+    });
+
+    return null;
+  }
+}
+
+
+
+async function validatePlayers(GameState, findings, strictMode) {
+  try {
+    const playersLoader = GameState.EntityLoaderRegistry.get('players');
+    if (!playersLoader) {
+      findings.push({
+        level: strictMode ? 'error' : 'warn',
+        code: 'PLAYERS_LOADER_MISSING',
+        message: 'No players entity loader configured',
+      });
+      return;
+    }
+
+    const playerRecords = await playersLoader.fetchAll();
+    for (const [playerName, playerRecord] of Object.entries(playerRecords || {})) {
+      const attributes = playerRecord && playerRecord.attributes;
+      if (!attributes || typeof attributes !== 'object') {
+        continue;
+      }
+
+      for (const attributeKey of Object.keys(attributes)) {
+        if (!GameState.AttributeFactory.has(attributeKey)) {
+          findings.push({
+            level: strictMode ? 'error' : 'warn',
+            code: 'UNKNOWN_PLAYER_ATTRIBUTE',
+            message: `Player has unknown attribute '${attributeKey}'`,
+            path: `data/player/${playerName}.json`,
+            detail: { player: playerName, attribute: attributeKey },
+          });
+        }
+      }
+    }
+  } catch (error) {
+    findings.push({
+      level: 'error',
+      code: 'PLAYER_VALIDATION_FAILED',
+      message: 'Failed while validating player attributes',
+      detail: {
+        message: error.message,
+        stack: error.stack,
+      },
+    });
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const jsonOnly = args.includes('--json');
+  const strictMode = args.includes('--strict');
+  const playersMode = args.includes('--players');
+  const engineMode = args.includes('--engine') || playersMode;
+  const root = process.cwd();
+  const findings = [];
+  const config = loadConfig(root, findings);
+
+  if (!jsonOnly) {
+    const modeParts = ['filesystem'];
+    if (engineMode) {
+      modeParts.push('engine');
+    }
+    if (playersMode) {
+      modeParts.push('players');
+    }
+
+    console.log(`[info] validate:bundles starting (${modeParts.join(', ')})`);
+  }
+
+  if (config) {
+    validateFilesystem(root, config, findings);
+
+    if (engineMode && !findings.some((finding) => finding.level === 'error')) {
+      const gameState = await validateEngineLoad(root, config, findings);
+      if (gameState && playersMode) {
+        await validatePlayers(gameState, findings, strictMode);
+      }
+    }
+  }
+
+  if (jsonOnly) {
+    process.stdout.write(`${JSON.stringify(findings, null, 2)}\n`);
+  } else {
+    findings.forEach((finding) => {
+      const line = formatFinding(finding);
+      if (finding.level === 'error') {
+        console.error(line);
+      } else {
+        console.warn(line);
+      }
+    });
+  }
+
+  const hasErrors = findings.some((finding) => finding.level === 'error');
+
+  if (!jsonOnly) {
+    const counts = summarizeFindings(findings);
+    console.log(`[info] validate:bundles complete (errors=${counts.error}, warnings=${counts.warn})`);
+  }
+
+  process.exit(hasErrors ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Allow deterministic execution of multi-step command sequences for lightweight scenario/smoke testing of the wrapper without starting transports. 
- Provide both repeatable inline commands and file-based sequences to make scenario definitions portable and scriptable. 
- Keep backward compatibility with the existing single-command mode (`--command` / `--args`) while improving UX for multi-command runs.

### Description

- Added `util/scenario-runner.js` which accepts repeatable `--command-line` entries and `--commands-file <path>` (line-separated, `#` comments and blanks ignored), parses sequences, boots the engine in no-transport mode, and executes commands in order while emitting progress and output. 
- Resolved command invocation semantics by looking up commands with `CommandManager.find(name, true)` and passing the resolved alias into `command.execute(args, player, alias)` so `arg0` semantics match interactive gameplay. 
- Added `test/scenario.example.test.js` to assert the runner help and new flags, and updated `package.json` with `scenario`, `validate:bundles`, and bundle-test scripts. 
- Introduced supporting tools and docs: `util/validate-bundles.js`, `util/test-bundles.js`, `test/bundles.contract.test.js`, and documentation updates in `docs/BundleValidationUserManual.md` demonstrating sequence usage and examples.

### Testing

- Ran `node util/scenario-runner.js --help` which printed usage and returned exit code 0. (passed)
- Ran the scenario help test with `node --test test/scenario.example.test.js` which completed successfully. (passed)
- Ran full test suite with `npm test` which completed and showed all tests passing (7 passing). (passed)
- Ran `npm run ci:local` to validate local CI parity; this failed in the current environment during `npm ci` due to network/SSH access to `github.com:22` being unreachable, which prevented dependency install (environment limitation, not a code failure). (failed - network)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8aad1cac8326b0659459bc9fa280)