### PR TITLE
Remove broken default bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
 
 ## Unreleased
 
+### Bundle defaults
+
+- Summary:
+  - Removed `bundle-example-areas` and `simple-crafting` from the default bundle set.
+- Why:
+  - Both bundles fail to load out of the box due to missing `quests.yml` files.
+  - Default installs should boot cleanly without requiring local bundle patches.
+- Impact:
+  - Fresh installs no longer auto-install or enable these bundles.
+  - Existing installs that still reference them will continue to fail until the bundles are fixed or removed.
+- Migration/Action:
+  - If you rely on these bundles, install and enable them manually after supplying the missing quest files.
+- References:
+  - PR #27 Remove broken default bundles
+- Timestamp: 2026.02.11 15:59
+
 ### Explicit startup failure handling
 
 - Summary:

--- a/util/init-bundles.js
+++ b/util/init-bundles.js
@@ -51,7 +51,6 @@ async function main() {
   }
 
   const defaultBundles = [
-    'https://github.com/Rantamuta/bundle-example-areas',
     'https://github.com/Rantamuta/bundle-example-channels',
     'https://github.com/Rantamuta/bundle-example-classes',
     'https://github.com/Rantamuta/bundle-example-combat',
@@ -63,7 +62,6 @@ async function main() {
     'https://github.com/Rantamuta/bundle-example-npc-behaviors',
     'https://github.com/Rantamuta/bundle-example-player-events',
     'https://github.com/Rantamuta/bundle-example-quests',
-    'https://github.com/Rantamuta/simple-crafting',
     'https://github.com/Rantamuta/vendor-npcs',
     'https://github.com/Rantamuta/player-groups',
     'https://github.com/Rantamuta/progressive-respawn',


### PR DESCRIPTION
- Summary:
  - Removed `bundle-example-areas` and `simple-crafting` from the default bundle set.
- Why:
  - Both bundles fail to load out of the box due to missing `quests.yml` files.
  - Default installs should boot cleanly without requiring local bundle patches.
- Impact:
  - Fresh installs no longer auto-install or enable these bundles.
  - Existing installs that still reference them will continue to fail until the bundles are fixed or removed.
- Migration/Action:
  - If you rely on these bundles, install and enable them manually after supplying the missing quest files.


