### PR TITLE
Add maintainers’ review of portable behavioral spec completeness

### DIFF
--- a/docs/portable-behavioral-spec-review.md
+++ b/docs/portable-behavioral-spec-review.md
@@ -103,3 +103,29 @@ This gives you consistency now, with very low implementation risk.
 4. Add transcript-style smoke checks for those three verbs.
 
 That sequence gives you a working, coherent command layer quickly, while leaving room to add richer parsing later only where evidence says it is needed.
+
+
+## Assessment of your latest updated spec draft
+
+Yes—this update answers the previously open questions and is now **implementation-ready** for a robust, contract-driven command layer.
+
+### What your update resolves well
+
+- It explicitly resolves the previously open strict-text boundary using a behavioral rule (non-diegetic commands strict-text, diegetic verbs semantic-equivalent).
+- It makes atomicity normative (no legacy non-atomic exceptions under the reference profile).
+- It declares a canonical delivery ordering profile and ties compatibility to a profile/version mechanism.
+- It adds deterministic verb resolution and grammar ownership constraints that reduce parser ambiguity.
+
+### Maintainer caution (scope control)
+
+Your draft is now strong enough that it can be treated as a **mandate** for the reference profile. The main tradeoff is that it is no longer "minimal"—it is intentionally prescriptive.
+
+Recommended adoption posture:
+
+1. Keep this as the **Reference Profile v1** contract.
+2. Keep implementation startup simple (split-token parser + verb-owned grammar patterns) as long as behavior satisfies the profile.
+3. Version any future behavioral changes rather than editing rules in place.
+
+### Practical next step
+
+Proceed to implementation using the 3-verb starter slice (`look`, `get`, `help`) under this profile. If those pass with deterministic outcomes and ordering, expand verb families incrementally.


### PR DESCRIPTION
### Motivation

- Provide a maintainer-level evaluation of the supplied Portable Behavioral Spec so the team can decide whether it is sufficient to port the command-to-output pipeline into Rantamuta.
- Record a concise verdict, identify underspecified areas, and propose a minimal addendum to reach parity-sensitive readiness.

### Description

- Add `docs/portable-behavioral-spec-review.md` containing a structured review that judges the spec sufficient for a similar-system port but not strict transcript-level parity without additions.
- The review lists strengths (stage order, failure taxonomy, canonical event fanout), enumerates 10 underspecified areas (grammar, target precedence, fallback semantics, validation ordering, atomicity, eligibility timing, delivery ordering, text-compatibility profile, concurrency, and error payload schema), and proposes a minimal “Spec v1.1” addendum.
- This is a documentation-only change with no runtime code, configuration, or lockfile modifications and minimal risk.

### Testing

- Ran `npm test`; the baseline test suite completed with 3 passing and 5 failing tests, with failures observed in bundle validation checks, scenario runner tests, and wrapper smoke tests.
- Ran `npm run ci:local`; the local CI runner failed during dependency installation due to an SSH/network error when attempting to fetch `ranvier-telnet` from GitHub, so `ci:local` did not complete successfully.
- No runtime changes were made and no additional automated tests were added for this docs-only PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2696c4448326b4faeecb70a12937)