### PR TITLE
docs: clarify q query helpers vs metadata value readers

### DIFF
--- a/docs/manuals/DesignerManual.md
+++ b/docs/manuals/DesignerManual.md
@@ -1445,8 +1445,11 @@ module.exports = {
 
 ### `q` Query Methods (Designer Reference)
 
-Inside a predicate, `q` is your read-only "question toolbox."  
-Each method asks one specific true/false question.
+Inside a predicate, `q` is your read-only query toolbox.  
+Most methods are true/false predicate helpers, and the metadata getters are value readers you can compare in your own boolean logic.
+
+- Value readers: `q.getRoomMetadata(...)`, `q.getAreaMetadata(...)`, `q.getWorldMetadata(...)`
+- Boolean helpers: all other `q.*` methods in this list
 
 1. `q.getRoomMetadata(roomRef, key)`
    Example idea: "What is the current room metadata value for a puzzle key?"


### PR DESCRIPTION
### Motivation
- Clarify that `q` in predicates contains both boolean predicate helpers and metadata getters that return arbitrary values, because the prior wording implied every `q` method was a true/false question.

### Description
- Updated `docs/manuals/DesignerManual.md` to replace the ambiguous intro with a concise explanation that `q` is a query toolbox, explicitly listing value readers (`q.getRoomMetadata`, `q.getAreaMetadata`, `q.getWorldMetadata`) and noting that all other `q.*` methods are boolean helpers.

### Testing
- No automated tests were run because this is a docs-only change; `npm test` and `npm run ci:local` were skipped per the docs-only validation guidance, and the file content was verified with `nl` before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7563de9488326bba35ea4fa9dbd1a)