### PR TITLE
Proposal: verb-local syntax matching draft and implementation plan

### DIFF
--- a/docs/drafts/VerbLocalSyntaxMatching.md
+++ b/docs/drafts/VerbLocalSyntaxMatching.md
@@ -86,6 +86,19 @@ Slot kinds (extensible):
 - `ENTITY`: broad resolvable target slot
 - `LIVING`: resolvable NPC + PC target slot
 - `ITEM`: resolvable object target slot
+- `MULTI_ENTITY`: multi-target entity capture
+- `MULTI_LIVING`: multi-target living capture
+
+Compatibility mapping to LIMA/MudOS-style parse tokens:
+
+- `OBJ` -> `ENTITY`
+- second `OBJ` (or `OBJ2`) -> indirect entity slot
+- `LIV` -> `LIVING`
+- `OBS` -> `MULTI_ENTITY`
+- `LVS` -> `MULTI_LIVING`
+- `WRD` -> `WORD`
+- `STR` -> `TEXT`
+- `PREP` -> `LITERAL(<connector>)` at declaration time
 
 ### Input Normalization Assumptions
 
@@ -101,21 +114,42 @@ Quoted content remains opaque text and is never structurally re-parsed by the ma
 
 ### Matching Algorithm
 
-Given ordered rules `R1..Rn`, evaluate in declaration order:
+Given ordered rules `R1..Rn`, evaluate in declaration order with a recursive backtracking matcher:
 
-1. Attempt full-pattern match of rule `Ri` against the verb remainder.
-2. A rule matches only if all pattern atoms match and all input is consumed (except explicit trailing `TEXT` slot capture by design).
-3. On first successful rule match, return a `syntaxArtifact` and stop.
-4. If no rule matches, return existing command-level parse failure/fallback path.
+1. **Pre-check literals (fast filter).**
+   - For each rule, run a cheap literal-presence/order gate before deep matching (equivalent intent to `check_literal(...)`).
+   - If required literal connectors cannot fit, skip rule immediately.
+2. **Token-by-token recursive match.**
+   - Walk pattern atoms against input tokens (`match(ruleIndex, tokenIndex)`).
+   - Record successful partial captures, recurse to the next atom, and backtrack on failure.
+3. **Accept only full matches.**
+   - Candidate success requires pattern exhaustion and input exhaustion, except a terminal `TEXT` slot that intentionally captures the remainder.
+4. **Candidate validation and selection.**
+   - For each structural candidate, run follow-on validation hooks and relation checks in existing command architecture terms.
+   - Select deterministic winner by rule order and quality scoring policy.
 
 Atom matching semantics:
 
 - `LITERAL(word)`: case-normalized equality with current token.
-- `SLOT(TEXT)`: greedy capture policy with backtracking to satisfy subsequent literal atoms.
-  - Practically: when followed by later literals, capture the largest span that still allows the rest of the pattern to match.
-  - If no later literals exist, capture entire remaining input.
-- `SLOT(WORD|NUMBER)`: consume exactly one token; validate kind immediately.
-- `SLOT(ENTITY|LIVING|ITEM)`: capture a candidate text span for resolver binding; matcher validates only structural fit, not world resolution.
+- `SLOT(TEXT)` (LIMA `STR` equivalent): tries one-or-more-token spans and recurses.
+  - Operationally this behaves as greedy capture with backtracking to satisfy later literals/slots.
+  - Quoted internals remain opaque text and are never structurally re-tokenized.
+- `SLOT(WORD|NUMBER)` (LIMA `WRD` analogue for `WORD`): consume exactly one token; validate kind immediately.
+- `SLOT(ENTITY|LIVING|ITEM|MULTI_ENTITY|MULTI_LIVING)` (LIMA `OBJ`/`LIV`/`OBS`/`LVS` analogues):
+  - capture candidate spans structurally during syntax match,
+  - defer world binding (nouns/adjectives/plurals/ordinals/`all`/`self`) to resolver phase.
+
+This ordering preserves the key LIMA property: literal token order is part of rule identity, so `OBJ with OBJ for STR` and `OBJ for STR with OBJ` are different rule shapes with different dispatch outcomes.
+
+### Validation/Dispatch Flow Parity
+
+After structural match, execution flow remains staged:
+
+1. build rule-shape-specific validation targets (conceptually like `can_`, `direct_`, `indirect_` phases),
+2. run relation validation for multi-entity forms where required,
+3. dispatch planner/executor path for the selected rule shape with arguments in declared slot order.
+
+The matcher does not bypass these phases; it only makes rule-shape selection explicit and verb-local.
 
 ### Deterministic Rule Selection and Ambiguity
 

--- a/docs/plans/2026-03-12-verb-local-syntax-matching-plan.md
+++ b/docs/plans/2026-03-12-verb-local-syntax-matching-plan.md
@@ -55,13 +55,13 @@ The implementation should provide a generic matcher, not a `say`-special parser.
 
 1. **Rule schema and loader**
    - Add ordered rule declarations per verb with atomized patterns (`LITERAL`, `SLOT`).
-   - Support extensible slot kinds (`TEXT`, `WORD`, `NUMBER`, `ENTITY`, `LIVING`, `ITEM`).
+   - Support extensible slot kinds (`TEXT`, `WORD`, `NUMBER`, `ENTITY`, `LIVING`, `ITEM`, `MULTI_ENTITY`, `MULTI_LIVING`) and compatibility mapping to LIMA-style tokens (`STR`, `WRD`, `OBJ`, `LIV`, `OBS`, `LVS`).
 2. **Deterministic matcher**
-   - Match rule list in declaration order (first full match wins).
+   - Match rule list in declaration order using recursive backtracking with a fast literal pre-check (LIMA-style flow).
    - Enforce full-pattern consumption semantics and deterministic behavior for identical input/state.
 3. **`TEXT` capture semantics**
    - Preserve quoted and unquoted text as opaque `TEXT` capture spans.
-   - Use greedy-with-backtracking behavior only to satisfy later literals; never reinterpret internals.
+   - Use one-or-more-token span search with backtracking to satisfy later literals; never reinterpret internals.
 4. **Syntax artifact contract**
    - Emit stable rule id, slot captures, and compatibility aliases for existing parse span names.
 5. **Resolver integration**
@@ -69,7 +69,7 @@ The implementation should provide a generic matcher, not a `say`-special parser.
    - Preserve non-entity slots verbatim for planner/render phases.
 6. **Validation and guardrails**
    - Add rule-order/ambiguity characterization tests.
-   - Add matcher tests that prove generic behavior across non-`say`-specific patterns.
+   - Add matcher tests that prove generic behavior across non-`say`-specific patterns, including literal-order shape differences (for example `... with ... for ...` vs `... for ... with ...`).
 
 ## Risks and Mitigations
 


### PR DESCRIPTION
### Motivation

- Move syntactic structure ownership from a global parser to individual verbs to avoid over-reading literal free-text (motivating example: `say`).
- Provide an incremental, reversible migration path that preserves compatibility by retaining broad `ENTITY` slots while enabling narrower slot kinds later.
- Pilot the approach for `say` and reuse existing verb rule categories (intransitive/direct/indirect) to minimize disruption to current parsing dispatch.

### Description

- Updated `docs/drafts/VerbLocalSyntaxMatching.md` to describe a two-stage parse model where verbs declare ordered syntax rules composed of literal words, free-text slots, and entity slots, and to add a slot-taxonomy migration posture that preserves `ENTITY` while allowing future `LIVING`/`ITEM` constraints.
- Added a new implementation plan at `docs/plans/2026-03-12-verb-local-syntax-matching-plan.md` that scopes an incremental pilot, lists in-scope surfaces (including a `say` pilot), defines acceptance criteria, and documents risks and mitigations.
- Clarified that the first matching verb-declared rule wins, and that entity resolution binds only the entity-bearing slots declared by the matched rule to preserve resolver ownership and compatibility.

### Testing

- No automated tests were run as part of this documentation-only change; the plan prescribes running `npm test` and `npm run ci:local` during implementation for unit and integration validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d342d52c8326af35c855516f61f8)