### PR TITLE
Add verb-local syntax matching design doc and implementation plan

### DIFF
--- a/docs/drafts/VerbLocalSyntaxMatching.md
+++ b/docs/drafts/VerbLocalSyntaxMatching.md
@@ -42,6 +42,20 @@ This is especially important for free-text verbs such as `say`, but the model sh
 
 ## Core Idea
 
+### Command Architecture Compatibility Guardrails
+
+This design is intentionally scoped to parsing and pattern matching only.
+
+Everything else in the current command architecture remains unchanged:
+
+- phase sequencing remains Receive Input (including parse) -> Entity Resolution -> Capture/Veto -> Plan -> React -> Commit -> Render/Dispatch,
+- mutation policy remains unchanged (no mutation outside Commit),
+- resolution policy ownership remains unchanged (Entity Resolution owns world-binding decisions),
+- capture/react/plan/commit/render contracts remain unchanged except for consuming the new syntax artifact.
+
+The migration goal is to change *how rule shape is selected*, not to redesign command phases or mutation semantics.
+
+
 Parsing becomes a two-stage operation:
 
 1. Resolve the verb from the first token.
@@ -54,9 +68,147 @@ A syntax rule is an ordered pattern composed of:
 - entity slots
 - future slot kinds such as number or single-word if needed
 
+The syntax layer should reuse existing verb rule categories (intransitive/direct/indirect and related forms) as the migration entry point rather than introducing a separate dispatch path.
+
 The first matching rule wins.
 
 Entity Resolution then binds only the entity slots declared by the matched rule.
+
+## Generic Pattern-Matching Model (Detailed)
+
+This section defines the matching behavior as a general mechanism, not a `say`-specific special case.
+
+### Rule Declaration Shape
+
+Each verb declares an ordered `syntaxRules` list.
+
+At the authored command surface, rules may be compact syntax strings.
+
+At runtime/load time, those strings can compile into richer internal rule objects used by the matcher. A compiled rule object may contain:
+
+- `id`: stable internal identifier for diagnostics/tests
+- `pattern`: ordered array of pattern atoms
+- `slots`: slot metadata keyed by slot name (type, constraints, resolver hints)
+- `semantics` (optional): rule-local flags used by planner/renderer (not by matcher)
+
+Pattern atoms:
+
+- `LITERAL(word)`: exact normalized token match (for example `to`, `with`, `in`)
+- `SLOT(name, kind)`: slot placeholder that consumes part of the remaining input
+
+Slot kinds (extensible):
+
+- `TEXT`: opaque text span; matcher does not interpret internal words
+- `WORD`: single token free-text slot
+- `NUMBER`: numeric token slot
+- `ENTITY`: broad resolvable target slot
+- `LIVING`: resolvable NPC + PC target slot
+- `ITEM`: resolvable object target slot
+- `MULTI_ENTITY`: multi-target entity capture
+- `MULTI_LIVING`: multi-target living capture
+
+Compatibility mapping to LIMA/MudOS-style parse tokens:
+
+- `OBJ` -> `ENTITY`
+- second `OBJ` (or `OBJ2`) -> indirect entity slot
+- `LIV` -> `LIVING`
+- `OBS` -> `MULTI_ENTITY`
+- `LVS` -> `MULTI_LIVING`
+- `WRD` -> `WORD`
+- `STR` -> `TEXT`
+- `PREP` -> `LITERAL(<connector>)` at declaration time
+
+### Input Normalization Assumptions
+
+Before rule matching:
+
+1. input is canonicalized using existing command input normalization
+2. verb token is resolved
+3. remainder is preserved as both:
+   - token stream (for literal and narrow-slot matching)
+   - raw remainder string slices (for opaque `TEXT` capture)
+
+Quoted content remains opaque text and is never structurally re-parsed by the matcher.
+
+### Matching Algorithm
+
+Given ordered rules `R1..Rn`, evaluate in declaration order with a recursive backtracking matcher:
+
+1. **Pre-check literals (fast filter).**
+   - For each rule, run a cheap literal-presence/order gate before deep matching (equivalent intent to `check_literal(...)`).
+   - If required literal connectors cannot fit, skip rule immediately.
+2. **Token-by-token recursive match.**
+   - Walk pattern atoms against input tokens (`match(ruleIndex, tokenIndex)`).
+   - Record successful partial captures, recurse to the next atom, and backtrack on failure.
+3. **Accept only full matches.**
+   - Candidate success requires pattern exhaustion and input exhaustion, except a terminal `TEXT` slot that intentionally captures the remainder.
+4. **Candidate validation and selection.**
+   - For each structural candidate, run follow-on validation hooks and relation checks in existing command architecture terms.
+   - Select deterministic winner by rule order and quality scoring policy.
+
+Atom matching semantics:
+
+- `LITERAL(word)`: case-normalized equality with current token.
+- `SLOT(TEXT)` (LIMA `STR` equivalent): tries one-or-more-token spans and recurses.
+  - Operationally this behaves as greedy capture with backtracking to satisfy later literals/slots.
+  - Quoted internals remain opaque text and are never structurally re-tokenized.
+- `SLOT(WORD|NUMBER)` (LIMA `WRD` analogue for `WORD`): consume exactly one token; validate kind immediately.
+- `SLOT(ENTITY|LIVING|ITEM|MULTI_ENTITY|MULTI_LIVING)` (LIMA `OBJ`/`LIV`/`OBS`/`LVS` analogues):
+  - capture candidate spans structurally during syntax match,
+  - defer world binding (nouns/adjectives/plurals/ordinals/`all`/`self`) to resolver phase.
+
+This ordering preserves the key LIMA property: literal token order is part of rule identity, so `OBJ with OBJ for STR` and `OBJ for STR with OBJ` are different rule shapes with different dispatch outcomes.
+
+### Validation/Dispatch Flow Parity
+
+After structural match, execution flow remains staged:
+
+1. build rule-shape-specific validation targets (conceptually like `can_`, `direct_`, `indirect_` phases),
+2. run relation validation for multi-entity forms where required,
+3. dispatch planner/executor path for the selected rule shape with arguments in declared slot order.
+
+The matcher does not bypass these phases; it only makes rule-shape selection explicit and verb-local.
+
+### Deterministic Rule Selection and Ambiguity
+
+Selection is deterministic by declaration order with two guardrails:
+
+- Prefer higher-specificity rules earlier (more literals, narrower slot kinds).
+- Keep a lint/check that flags equal-shape ambiguous rules whose ordering could hide one another.
+
+If two rules both structurally match, earlier declaration wins; this is intentional and testable.
+
+### Syntax Artifact Contract
+
+Matcher output should be a stable artifact consumed by Entity Resolution and Planner:
+
+- `verb`: resolved verb key
+- `ruleId`: matched rule id
+- `ruleForm`: existing verb-form category (intransitive/direct/indirect/etc.)
+- `slots`: captured slot spans with:
+  - `name`
+  - `kind`
+  - `raw` (exact text)
+  - `tokenRange` (start/end indices in remainder token list)
+- compatibility aliases for existing parse names (`primaryTargetSpan`, `secondaryTargetSpan`) during migration
+
+### Entity Binding Handoff
+
+Entity Resolution consumes only entity-bearing slots (`ENTITY`, `LIVING`, `ITEM`, future entity-like kinds):
+
+- resolver binds candidates according to slot kind + scope profile
+- non-entity slots (especially `TEXT`) are passed through unchanged
+- unresolved addressed forms that rely on entity binding fall back to literal interpretation when command policy says so (current `say` direction)
+
+### Extensibility Rules
+
+To add new syntax capability, introduce a new slot kind or literal pattern, not a verb-specific parser branch.
+
+Examples of future-safe extension points:
+
+- add `DIRECTION` slot kind for exits
+- add slot constraint metadata (`minTokens`, `maxTokens`, `allowedScopes`)
+- add compile-time rule validation (unreachable rule detection, ambiguity checks)
 
 ## Why `say` Is the Motivating Case
 
@@ -84,6 +236,8 @@ A minimal `say` rule set would look conceptually like:
 - `TEXT`
 - `TEXT to ENTITY`
 
+Near-term migration should keep `ENTITY` as the broad compatibility slot. Longer-term, the slot taxonomy can support narrower forms such as `LIVING` (NPC/PC targets) and `ITEM` without removing `ENTITY`.
+
 Interpretation:
 
 - `say hello there`
@@ -98,6 +252,23 @@ Interpretation:
   - remains `TEXT` unless the trailing `to <entity>` actually matches a valid addressed form
 
 This keeps literal speech as the default and makes addressed speech an explicit verb-owned form.
+
+## Slot Taxonomy Direction
+
+`ENTITY` should remain available as the broadest entity-bearing placeholder for compatibility and incremental migration.
+
+Syntax matching should also allow narrower slot kinds as optional future constraints, for example:
+
+- `LIVING`: actor-like targets (NPC + PC)
+- `ITEM`: object-like targets
+
+The naming and classification should be syntax-facing and gameplay-readable. Engine-specific classes (for example, scriptability internals) should be mapped in entity resolution metadata rather than hardcoded into parser rule matching.
+
+Migration posture for `say`:
+
+- migrate `say` to verb-local syntax with `TEXT` and `TEXT to ENTITY` as the baseline addressed/public forms
+- keep `ENTITY` available as the broad slot while supporting optional narrower forms like `TEXT to LIVING` where content policy wants NPC+PC targeting
+- avoid removing `ENTITY` until behavior and content expectations are validated
 
 ## General Use Beyond `say`
 
@@ -169,18 +340,37 @@ A likely future phase split is:
 - match the remaining input against that verb’s syntax rules
 - produce a syntax artifact
 
+(Parsing/matching is explicitly represented inside Receive Input; it does not introduce a new downstream phase.)
+
 ### Entity Resolution
 
 - bind entity slots declared by the matched syntax rule
 - preserve free-text slots without entity binding
 - apply rule-specific scope and accepted-relation logic
 
+### Capture/Veto
+
+- consume resolved entities and enforce policy checks
+- deny/allow without mutation
+
 ### Plan
 
 - decide command-specific fallback behavior when binding is unresolved but recoverable
-- render literal vs directed speech, or equivalent command outcomes
+- produce deterministic planned operations and base render intent
 
-This keeps the parser generic without forcing it to guess semantics that belong later.
+### React
+
+- add post-validation render/reaction contributions without direct mutation
+
+### Commit
+
+- apply planned operations transactionally
+
+### Render/Dispatch
+
+- deliver output after successful commit
+
+This keeps the parser generic without forcing it to guess semantics that belong later. It also preserves existing command architecture boundaries by changing only syntax selection, not downstream phase responsibilities.
 
 ## Advantages
 
@@ -210,14 +400,11 @@ A low-risk migration path would be:
 
 ## Open Questions
 
-- whether syntax matching should replace current generic parse shapes or coexist with them
-- how free-text slots should interact with quoted spans
-- whether the syntax artifact should reuse current names such as `primaryTargetSpan` / `secondaryTargetSpan`
+- for `say`, syntax matching replaces the current generic relation-splitting path (full migration of `say` input handling)
+- quoted spans are preserved as opaque `TEXT` placeholders; parser/syntax layers do not reinterpret quoted internals
+- for compatibility, syntax artifacts should initially reuse current names such as `primaryTargetSpan` / `secondaryTargetSpan`
 - how rule ordering should be declared and validated
-- whether unresolved entity-bearing syntax forms should be command-configurable as:
-  - hard failure
-  - fallback to literal
-  - disambiguation prompt
+- unresolved entity-bearing addressed forms should fall back to literal text
 - how much of current relation handling should remain in generic parser code once verb-local syntax exists
 
 ## Summary

--- a/docs/plans/2026-03-12-verb-local-syntax-matching-plan.md
+++ b/docs/plans/2026-03-12-verb-local-syntax-matching-plan.md
@@ -1,0 +1,394 @@
+# Verb-Local Syntax Matching Implementation Plan
+
+## Status
+
+- Status: draft
+- Scope: bundle-layer command parsing and rule selection
+- Binding: no (planning artifact)
+
+---
+
+## Goal
+
+Establish verb-local syntax matching as the primary model for command shape.
+
+Instead of a global parser attempting to infer structure from relation-like words, each verb explicitly declares the syntax patterns it supports.
+
+The system then matches player input against those patterns and produces a stable interpretation artifact used by later command phases.
+
+This design is motivated by free-text verbs such as `say`, but the model is general and should become the normal command declaration model.
+
+---
+
+## Design Principles
+
+1. **Structure is declared by the verb**
+
+   Command grammar is defined by verb syntax rules rather than inferred globally.
+
+2. **Literal connector words are rule-local**
+
+   Words such as `to`, `with`, `for`, or `in` are structural only when they appear inside a declared syntax rule.
+
+3. **Rules are evaluated in explicit order**
+
+   Rule priority is determined only by declaration order. The first rule that successfully matches becomes the winner.
+
+4. **Parsing and entity resolution are linked**
+
+   Entity-bearing slots participate in rule viability during matching.
+
+5. **Later command phases remain unchanged**
+
+   Veto, Plan, React, Commit, and Render are outside the scope of this effort.
+
+---
+
+## Command Interpretation Model
+
+Input handling is divided into a small preparation step followed by a linked parsing-and-entity-resolution step.
+
+### Receive Input
+
+Responsibilities:
+
+- canonicalize raw input
+- tokenize or lex input
+- resolve the verb key
+
+No structural interpretation occurs here beyond identifying the verb.
+
+### Parsing and Entity Resolution
+
+This step performs rule matching and entity-bearing slot interpretation together.
+
+Responsibilities:
+
+- load ordered syntax rules for the verb
+- match candidate rules against the remaining token stream
+- treat literal connector words as structural only when declared by the rule
+- capture slot spans during matching
+- interpret entity-bearing slots as part of rule viability
+- reject rules when structure or entity interpretation fails
+- emit a final interpretation artifact
+
+Structural matching and entity-bearing interpretation co-determine rule viability.
+
+---
+
+## Command Architecture Integration
+
+This section describes how verb-local syntax matching fits into the current command architecture and what should be clarified in the command architecture document itself.
+
+The goal is to make the interpretation step explicit without changing the behavior or responsibilities of later phases.
+
+### Recommended architecture wording
+
+The command architecture should describe the early pipeline as:
+
+`Receive Input -> Parsing and Entity Resolution -> Capture/Veto -> Plan -> React -> Commit -> Render/Dispatch`
+
+This does not introduce a new downstream behavior. It clarifies that command meaning is established by a linked parsing-and-resolution step before later phases consume the result.
+
+### Interpretation artifact
+
+Parsing and Entity Resolution should produce a stable interpretation artifact consumed by later phases.
+
+That artifact should contain:
+
+- resolved verb
+- matched syntax rule
+- captured slot values
+- resolved entity references where applicable
+
+Later phases should treat this artifact as the canonical description of the command.
+
+### Required normative update to command architecture
+
+`docs/normative/CommandArchitecture.md` must be updated to:
+
+1. replace wording that implies syntax parsing completes independently before entity resolution begins
+2. describe rule matching and entity-bearing interpretation as a linked interpretation step
+3. state that later phases consume a completed interpretation artifact
+4. keep phase responsibilities after interpretation unchanged
+
+No downstream behavioral change to command execution is required beyond making the interpretation stage explicit in normative wording.
+
+---
+
+## Rule Model
+
+Each verb declares an ordered list of syntax rules.
+
+Rules define the command grammar for that verb.
+
+Rule order is authoritative.
+
+The first rule that matches successfully becomes the selected rule.
+
+Rules are declared as compact space-separated syntax strings.
+
+Example:
+
+```js
+syntaxRules: [
+  'TEXT',
+  'TEXT to ENTITY'
+]
+```
+
+Each syntax string is compiled at load time into an ordered internal pattern used by the matcher.
+
+This keeps command declarations compact while still allowing the matcher to work with explicit structural patterns.
+
+Authored command declarations should remain compact strings and should intentionally avoid explicit authored rule IDs and authored per-rule metadata unless absolutely necessary.
+
+---
+
+## Syntax Strings
+
+Syntax rules are declared as compact space-separated strings.
+
+Examples:
+
+- `TEXT`
+- `TEXT to ENTITY`
+- `ENTITY in ENTITY`
+- `ENTITY with ENTITY for TEXT`
+
+At load time, each syntax string is compiled into an internal ordered pattern used by the matcher.
+
+Compilation should treat:
+
+- recognized symbolic slot tokens as slot placeholders
+- all other words as literal connector tokens
+
+Supported slot kinds for the initial implementation:
+
+- `TEXT`
+- `WORD`
+- `NUMBER`
+- `ENTITY`
+
+Additional kinds may be introduced later if required (for example `LIVING` when actor-only targeting constraints are needed).
+
+This representation is intentionally minimal. It avoids legacy rule-form metadata and explicit rule identifiers in command declarations.
+
+---
+
+## Matching Engine
+
+Rule matching uses recursive backtracking.
+
+### Deterministic rule order
+
+Rules are evaluated strictly in declaration order.
+
+The first rule that fully matches and satisfies entity-bearing interpretation wins.
+
+No implicit weighting or hidden precedence rules are used.
+
+### Recursive exploration
+
+Matching proceeds token by token.
+
+Free-text slots may capture larger spans initially and shrink during backtracking in order to satisfy later literals or entity slots.
+
+This allows commands such as:
+
+`say hello there to bob`
+
+to correctly match the rule:
+
+`TEXT to ENTITY`
+
+### Literal pre-check
+
+A fast literal presence check may be performed before deep matching.
+
+This serves only as an optimization gate.
+
+Full positional correctness is verified during recursive matching.
+
+### Entity slot participation
+
+Entity-bearing slots participate in candidate viability during matching.
+
+A candidate rule may be rejected if required entity-bearing slots cannot be interpreted according to the slot type.
+
+### Capture semantics
+
+- quoted and unquoted text is preserved as opaque spans
+- text slots use greedy capture with backtracking
+- literal connectors must match exact tokens
+
+---
+
+## Syntax Artifact
+
+When a rule succeeds the matcher produces a syntax artifact.
+
+Artifact contents:
+
+- resolved verb
+- matched syntax rule
+- captured slot values
+- token ranges
+- resolved entity references where applicable
+
+Compatibility aliases may be produced during migration.
+
+If later phases need stable internal identifiers, those may be derived internally from declaration order or compiled matcher state rather than authored explicitly in command content.
+
+---
+
+## Fallback Policy
+
+Some verbs may declare both:
+
+- a general text form
+- a more specific entity-addressed form
+
+If the entity-bearing form fails to resolve its entity slot, a verb may optionally fall back to the less specific text form.
+
+Fallback behavior must be explicitly declared by command semantics.
+
+Current `say` direction in this repository: unresolved addressed forms fall back to literal text.
+
+It is not a global parser behavior.
+
+---
+
+## Example: `say`
+
+Minimal rule set:
+
+- `TEXT`
+- `TEXT to ENTITY`
+
+Expected behavior:
+
+- `say hello there` -> `TEXT`
+- `say hello there to bob` -> `TEXT to ENTITY`
+- `say to be or not` -> `TEXT`
+
+Connector words inside speech remain literal unless the rule explicitly matches an addressed form.
+
+---
+
+## General Use Beyond `say`
+
+The system supports typical command verbs.
+
+Examples:
+
+### `put`
+
+- `ENTITY in ENTITY`
+- `ENTITY on ENTITY`
+
+### `give`
+
+- `ENTITY to ENTITY`
+
+### `search`
+
+- `ENTITY`
+- `for TEXT`
+- `ENTITY with ENTITY`
+- `ENTITY for TEXT`
+
+### `look`
+
+- `(empty)`
+- `ENTITY`
+
+---
+
+## Migration Strategy
+
+The goal is a single command syntax model.
+
+Migration sequence:
+
+1. implement verb-local syntax rule support
+2. implement the recursive matcher
+3. migrate `say`
+4. convert remaining legacy commands when mappings are straightforward
+5. remove the legacy parser once conversion is complete
+
+Legacy parsing exists only as a temporary bridge.
+
+No new command should be authored on the legacy parser model once verb-local syntax exists.
+
+---
+
+## Out of Scope
+
+The following command phases remain unchanged:
+
+- Capture/Veto
+- Plan
+- React
+- Commit
+- Render/Dispatch
+
+No mutation semantics or downstream command behavior are modified.
+
+Also out of scope:
+
+- changes to engine internals under `Rantamuta/core`
+- CLI, config, boot, load-order, or tick compatibility changes
+- broad refactors unrelated to syntax matching and command migration
+- narrowing broad compatibility slot behavior without explicit design approval
+
+---
+
+## Risks
+
+### Rule ambiguity
+
+Mitigation: rule ordering and tests.
+
+### Behavior drift during migration
+
+Mitigation: characterization tests for converted commands.
+
+### Parser scope creep
+
+Mitigation: keep later command phases strictly outside parsing and entity resolution.
+
+---
+
+## Acceptance Criteria
+
+1. verbs declare ordered syntax rules
+2. rule declaration order determines priority
+3. recursive matching handles text spans correctly
+4. entity-bearing slots influence rule viability
+5. the syntax artifact is produced deterministically
+6. downstream command phases remain unchanged
+7. `say` migration succeeds
+8. legacy commands continue working until converted
+9. `docs/normative/CommandArchitecture.md` is updated to reflect linked Parsing and Entity Resolution wording
+
+---
+
+## Validation
+
+Evidence required:
+
+- unit tests for rule matching
+- tests for literal ordering behavior
+- tests for entity-slot participation
+- tests for `say` speech edge cases
+- characterization tests for migrated legacy commands
+
+Required commands:
+
+- `npm test`
+- `npm run ci:local`
+
+Success condition:
+
+Matching behavior is deterministic and legacy commands remain stable until migration is complete.


### PR DESCRIPTION
### Motivation
- Clarify and formalize moving syntax-ownership from the global parser to individual verbs to avoid over-reading free-text verbs like `say` and to make connector words structural only when declared by a verb. 
- Provide a migration path that preserves existing command architecture and phase responsibilities while enabling deterministic, verb-local rule selection and entity-binding handoff. 
- Document compatibility and extensibility constraints to support incremental migration and future slot kinds such as `LIVING` or `ITEM`.

### Description
- Expanded `docs/drafts/VerbLocalSyntaxMatching.md` with a full specification covering rule declaration shape, matching algorithm (recursive backtracking with literal pre-check), slot kinds (`TEXT`, `WORD`, `ENTITY`, etc.), syntax artifact contract, entity binding handoff, determinism rules, and `say`-specific migration guidance. 
- Added compatibility guardrails to preserve existing command phases and mutation/resolution ownership while only changing syntax-selection responsibility. 
- Added a new implementation plan at `docs/plans/2026-03-12-verb-local-syntax-matching-plan.md` that prescribes declaration syntax, matcher design, testing/validation requirements, migration steps (migrate `say` first), and acceptance criteria. 
- Specified recommended validation commands and required unit/test types and kept the change scoped to interpretation (no runtime mutation or execution-phase behavior changes).

### Testing
- No automated tests were run as part of this documentation/plan change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d342d52c8326af35c855516f61f8)