### PR TITLE
Organize bundle lib layout

### DIFF
--- a/util/message.js
+++ b/util/message.js
@@ -31,7 +31,8 @@ const messageModulePath = path.resolve(
   'bundles',
   'bundle-rantamuta',
   'lib',
-  'session',
+  'runtime',
+  'command',
   'semantic-message.js'
 );
 // eslint-disable-next-line global-require, import/no-dynamic-require


### PR DESCRIPTION
## Summary
- update `util/message.js` to follow the paired `bundle-rantamuta` lib reorganization
- keep the wrapper CLI aligned with the moved semantic message module
- carry the wrapper-side companion change for the `organize-lib` bundle PR

## Validation
- `npm test`
- `npm run ci:local -- --force`
